### PR TITLE
Rename workflow and update branch names

### DIFF
--- a/.github/workflows/web-sdk.yml
+++ b/.github/workflows/web-sdk.yml
@@ -1,13 +1,13 @@
-name:  Web3-Onboard
+name: Web-SDK
 on:
   pull_request:
     branches:
-      - develop
-      - master 
+      - master
+      - main 
   push:
     branches:
-      - develop
       - master
+      - main
 
 jobs:
   master:
@@ -18,18 +18,14 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Web3-Onboard
+      - name: Web-SDK
         uses: actions/setup-node@v3
         with:
           node-version: '18''20''22'
           cache: 'yarn''npm''pnpm'     
-      - name:  Web3-Onboard & Web SDK 
+      - name:  Web SDK 
         id:  Install the Web SDK dependencies 
         run: |
-          npm i @web3-onboard/core @web3-onboard/injected-wallets ethers
-          # or
-          yarn add @web3-onboard/core @web3-onboard/injected-wallets ethers 
-          #Install the Web SDK dependencies   
           npm install @0xsequence/connect @0xsequence/hooks wagmi ethers viem 0xsequence @tanstack/react-query
           # or
           pnpm install @0xsequence/connect @0xsequence/hooks wagmi ethers viem 0xsequence @tanstack/react-query


### PR DESCRIPTION
### Description
<!-- Add a description of the fix or feature here -->


#### **_PLEASE NOTE- Checklist must be complete prior to review._**
### Checklist
- [ ] Increment the version field in `package.json` of the package you have made changes in following [semantic versioning](https://semver.org/) and using alpha release tagging
- [ ] Check the box that allows repo maintainers to update this PR
- [ ] Test locally to make sure this feature/fix works
- [ ] Run `yarn check-all` to confirm there are not any associated errors
- [ ] Confirm this PR passes Circle CI checks
- [ ] Add or update relevant information in the documentation

### Docs Checklist
- [ ] Include a screenshot of any changes ([see docs README on running locally](https://github.com/blocknative/web3-onboard/blob/develop/docs/README.md))
- [ ] Add/update the appropriate package README (if applicable)
- [ ] Add/update the related module in the [docs demo](https://github.com/blocknative/web3-onboard/blob/develop/docs/src/lib/services/onboard.js) (if applicable)
- [ ] Add/update the related package in the `docs/package.json` file (if applicable)

### If this PR includes changes to add an injected wallet or SDK wallet module: 
Please complete the following using the internal demo package.
To run this demo use the command `yarn && yarn dev` to get the project running at `http://localhost:8080/`

#### Tests with demo app (injected)
- [ ] send transaction
- [ ] switch chains
- [ ] sign message
- [ ] sign typed message
- [ ] disconnect

#### Tests with demo app (SDK)
- [ ] send transaction
- [ ] switch chains
- [ ] sign message
- [ ] sign typed message
- [ ] disconnect

## Summary by Sourcery

Update the GitHub Actions workflow configuration for the web SDK to reflect new naming and branch conventions.

CI:
- Rename the web SDK workflow and job labels to use 'Web-SDK' branding.
- Adjust workflow triggers to run on 'master' and 'main' branches instead of 'develop'.
- Simplify the dependency installation step to install only the Web SDK-related packages.