### PR TITLE
Update workflow to use only 'sw-dev' branch

### DIFF
--- a/.github/workflows/sw-build.yml
+++ b/.github/workflows/sw-build.yml
@@ -2,11 +2,9 @@ name: SubWallet Build
 on:
   pull_request:
     branches:
-      - main
       - sw-dev
   push:
     branches:
-      - main
       - sw-dev
 
 jobs:


### PR DESCRIPTION
Remove 'main' branch from pull request and push triggers.

### Description
<!-- Add a description of the fix or feature here -->


#### **_PLEASE NOTE- Checklist must be complete prior to review._**
### Checklist
- [ ] Increment the version field in `package.json` of the package you have made changes in following [semantic versioning](https://semver.org/) and using alpha release tagging
- [ ] Check the box that allows repo maintainers to update this PR
- [ ] Test locally to make sure this feature/fix works
- [ ] Run `yarn check-all` to confirm there are not any associated errors
- [ ] Confirm this PR passes Circle CI checks
- [ ] Add or update relevant information in the documentation

### Docs Checklist
- [ ] Include a screenshot of any changes ([see docs README on running locally](https://github.com/blocknative/web3-onboard/blob/develop/docs/README.md))
- [ ] Add/update the appropriate package README (if applicable)
- [ ] Add/update the related module in the [docs demo](https://github.com/blocknative/web3-onboard/blob/develop/docs/src/lib/services/onboard.js) (if applicable)
- [ ] Add/update the related package in the `docs/package.json` file (if applicable)

### If this PR includes changes to add an injected wallet or SDK wallet module: 
Please complete the following using the internal demo package.
To run this demo use the command `yarn && yarn dev` to get the project running at `http://localhost:8080/`

#### Tests with demo app (injected)
- [ ] send transaction
- [ ] switch chains
- [ ] sign message
- [ ] sign typed message
- [ ] disconnect

#### Tests with demo app (SDK)
- [ ] send transaction
- [ ] switch chains
- [ ] sign message
- [ ] sign typed message
- [ ] disconnect

## Summary by Sourcery

CI:
- Update the SubWallet build workflow triggers so that pull_request and push events run only for the sw-dev branch, removing main from the branch filters.